### PR TITLE
Set Chromatic story width to 64px

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,6 +1,6 @@
 <style>
   html {
-    max-width: 5em;
+    max-width: 64px;
   }
 
   * {
@@ -9,14 +9,14 @@
 
   div.icon {
     margin: 1em;
-    max-width: 5em;
+    max-width: 2em;
   }
 
   svg {
     color: red;
     min-width: 2em;
     min-height: 2em;
-    min-height: 3em;
+    max-height: 3em;
     max-height: 3em;
   }
 </style>


### PR DESCRIPTION
Stories are rendering at 572px, when icons will never be that wide. Chromatic measures snapshot usage by pixel count (up to 25m pixels), properly constraining this gives us a _lot_ of height to play with.

Styled Icons already locks this width to 64px.