### PR TITLE
Only run Chromatic tests on non-Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn chromatic --exit-once-uploaded --exit-zero-on-changes
+        if: github.actor != 'dependabot[bot]'
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 


### PR DESCRIPTION
We're hitting the test limit on Chromatic, this will instead run Chromatic only on human PRs (which are necessary for changesets anyways).