### PR TITLE
Shrink Storybook icons to 24x24px

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -22,7 +22,7 @@
 
   svg {
     color: red;
-    max-height: 32px;
-    max-width: 32px;
+    max-height: 24px;
+    max-width: 24px;
   }
 </style>


### PR DESCRIPTION
We have hit the Storybook size limit for `simple-icons`, this PR shrinks preview icons to 24x24 pixels.